### PR TITLE
NOJIRA: Bump dependencies

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,8 +9,8 @@ CACHE_DIR=$2
 VENDOR_DIR="$BUILD_DIR/vendor"
 INSTALL_DIR="$VENDOR_DIR/imagemagick-webp"
 
-LIBWEBP_VERSION="${LIBWEBP_VERSION:-1.3.1}"
-IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-7.1.1-12}"
+LIBWEBP_VERSION="${LIBWEBP_VERSION:-1.3.2}"
+IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-7.1.1-18}"
 
 CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION-webp-$LIBWEBP_VERSION.tar.xz"
 
@@ -38,7 +38,7 @@ if [ ! -f $CACHE_FILE ]; then
     exit 1;
   fi
   tar xvf $BUILD_DIR/$LIBWEBP_FILE | indent
-  
+
   echo "-----> Building libwebp"
   cd $LIBWEBP_DIR
   ./configure --prefix=$INSTALL_DIR


### PR DESCRIPTION
- libwebp to 1.3.2
- imagemagick to 7.1.1-18
- Addresses CVE-2023-5129